### PR TITLE
migrate to kub1.16 with backward compatibility

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: pgadmin
 version: 0.1.10
-appVersion: 4.12.0
+appVersion: 4.13.0
 description: pgAdmin is a web based administration tool for the PostgreSQL database.
 keywords:
   - pgadmin

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -5,7 +5,16 @@ Expand the name of the chart.
 {{- define "pgadmin.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "pgadmin.deployment.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "pgadmin.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "pgadmin.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "pgadmin.fullname" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
In k8s v1.16 some APIs are deprecated and removed.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

As a result, installation failed. I migrate to use supported API versions.
